### PR TITLE
Avoid AttributeError: 'NoneType' object has no attribute 'get'

### DIFF
--- a/settings_gui.py
+++ b/settings_gui.py
@@ -22,10 +22,10 @@ class EngineSettingsGUI:
         self.username = tk.StringVar(value=self.config.get("username", ""))
         self.password = tk.StringVar(value=self.config.get("password", ""))
         self.proxy_http = tk.StringVar(
-            value=self.config.get("proxies").get("http", "")
+            value=self.config.get("proxies").get("http", "") if isinstance(self.config.get("proxies"), dict) else None
         )
         self.proxy_https = tk.StringVar(
-            value=self.config.get("proxies").get("https", "")
+            value=self.config.get("proxies").get("https", "") if isinstance(self.config.get("proxies"), dict) else None
         )
 
         self.date = tk.BooleanVar(value=self.config.get("torrentDate", True))


### PR DESCRIPTION
This fixes the issue where, on Python 3.10.4, the following traceback is being generated when trying to run `settings_gui.py` without type checking:

```sh
Traceback (most recent call last):
  File "%USERPROFILE%\AppData\Local\qBittorrent\nova3\settings_gui.py", line 116, in <module>
    settings = EngineSettingsGUI("engines/kinozal")
  File "%USERPROFILE%\AppData\Local\qBittorrent\nova3\settings_gui.py", line 25, in __init__
    value=self.config.get("proxies").get("http", "")
AttributeError: 'NoneType' object has no attribute 'get'