### PR TITLE
Add publication date field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 [![Python 3.7+](https://img.shields.io/badge/python-%3E%3D%20v3.7-blue)](https://www.python.org/downloads/release/python-370/)
 # qBittorrent plugins
 
-## Rutracker.org ![v1.9](https://img.shields.io/badge/v1.9-blue)
+## Rutracker.org ![v1.10](https://img.shields.io/badge/v1.10-blue)
 Biggest russian torrent tracker.
 
-## Rutor.org ![v1.8](https://img.shields.io/badge/v1.8-blue)
+## Rutor.org ![v1.9](https://img.shields.io/badge/v1.9-blue)
 Popular free russian torrent tracker. http://rutor.info/ and http://rutor.is/ - actual domains at this time.
 
-## Kinozal.tv ![v2.12](https://img.shields.io/badge/v2.12-blue)
+## Kinozal.tv ![v2.13](https://img.shields.io/badge/v2.13-blue)
 Russian torrent tracker mostly directed on movies, but have other categories.
 
 The site has a restriction on downloading torrent files (10 by default or so), so I added the ability to open the magnet link instead the file.
@@ -27,7 +27,7 @@ According of the name of search plugin:
   * Windows: `%localappdata%\qBittorrent\nova3\engines`
   * Linux: `~/.local/share/qBittorrent/nova3/engines`
   * OS X: `~/Library/Application Support/qBittorrent/nova3/engines`
-* ... or you can put `settings_gui.py` into parent folder (nova3) and after this you can double-click on `*.py` file, or `Open with... -> Python`, and you should see graphic interface of your data :) 
+* ... or you can put `settings_gui.py` into parent folder (nova3) and after this you can double-click on `*.py` file, or `Open with... -> Python`, and you should see graphic interface of your data :)
 
 Description of `*.json` file:
 ```
@@ -71,4 +71,4 @@ _*make sure that your proxy work with right protocol_
 ## Troubleshooting
 All errors will appear directly in qBittorrent as searching result.
 * torrent tracker return 403 error:
-  - Some sites, sometimes, enable protection like CloudFlare, that required JavaScript. Vanilla Python has no implementation of JavaScript, it means that search engine will be return 403 error. 
+  - Some sites, sometimes, enable protection like CloudFlare, that required JavaScript. Vanilla Python has no implementation of JavaScript, it means that search engine will be return 403 error.

--- a/engines/rutor.py
+++ b/engines/rutor.py
@@ -1,4 +1,4 @@
-# VERSION: 1.8
+# VERSION: 1.9
 # AUTHORS: imDMG [imdmgg@gmail.com]
 
 # Rutor.org search engine plugin for qBittorrent
@@ -84,7 +84,6 @@ class EngineError(Exception):
 class Config:
     # username: str = "USERNAME"
     # password: str = "PASSWORD"
-    torrent_date: bool = True
     magnet: bool = False
     proxy: bool = False
     # dynamic_proxy: bool = True
@@ -170,24 +169,23 @@ class Rutor:
 
     def draw(self, html: str) -> None:
         for tor in RE_TORRENTS.findall(html):
-            torrent_date = ""
-            if config.torrent_date:
-                # replace names month
-                months = ("Янв", "Фев", "Мар", "Апр", "Май", "Июн",
-                          "Июл", "Авг", "Сен", "Окт", "Ноя", "Дек")
-                ct = [unescape(tor[0].replace(m, f"{i:02d}"))
-                      for i, m in enumerate(months, 1) if m in tor[0]][0]
-                ct = time.strftime("%y.%m.%d", time.strptime(ct, "%d %m %y"))
-                torrent_date = f"[{ct}] "
+            # replace names month
+            months = ("Янв", "Фев", "Мар", "Апр", "Май", "Июн",
+                        "Июл", "Авг", "Сен", "Окт", "Ноя", "Дек")
+            ct = [unescape(tor[0].replace(m, f"{i:02d}"))
+                    for i, m in enumerate(months, 1) if m in tor[0]][0]
+            time_obj = time.strptime(ct, "%d %m %y")
+            unix_timestamp = int(time.mktime(time_obj))
 
             prettyPrinter({
                 "engine_url": self.url,
                 "desc_link": self.url + tor[2],
-                "name": torrent_date + unescape(tor[4]),
+                "name": unescape(tor[4]),
                 "link": tor[1] if config.magnet else self.url_dl + tor[3],
-                "size": unescape(tor[5]),
+                "size": unescape(tor[5].replace("&nbsp;", " ")),
                 "seeds": unescape(tor[6]),
-                "leech": unescape(tor[7])
+                "leech": unescape(tor[7]),
+                "pub_date": unix_timestamp
             })
 
     def _catch_errors(self, handler: Callable, *args: str):

--- a/engines/rutracker.py
+++ b/engines/rutracker.py
@@ -1,4 +1,4 @@
-# VERSION: 1.9
+# VERSION: 1.10
 # AUTHORS: imDMG [imdmgg@gmail.com]
 
 # rutracker.org search engine plugin for qBittorrent
@@ -88,7 +88,6 @@ class EngineError(Exception):
 class Config:
     username: str = "USERNAME"
     password: str = "PASSWORD"
-    torrent_date: bool = True
     proxy: bool = False
     # dynamic_proxy: bool = True
     proxies: dict = field(default_factory=lambda: {"http": "", "https": ""})
@@ -195,17 +194,16 @@ class Rutracker:
 
     def draw(self, html: str) -> None:
         for tor in RE_TORRENTS.findall(html):
-            local = time.strftime("%y.%m.%d", time.localtime(int(tor[5])))
-            torrent_date = f"[{local}] " if config.torrent_date else ""
 
             prettyPrinter({
                 "engine_url": self.url,
                 "desc_link": self.url + "viewtopic.php?t=" + tor[0],
-                "name": torrent_date + unescape(tor[1]),
+                "name": unescape(tor[1]),
                 "link": self.url_dl + tor[0],
                 "size": tor[2],
                 "seeds": max(0, int(tor[3])),
-                "leech": tor[4]
+                "leech": tor[4],
+                "pub_date": int(tor[5])
             })
 
     def _catch_errors(self, handler: Callable, *args: str):


### PR DESCRIPTION
A new field has been added to qbittorrent:
> `pub_date` => unix timestamp corresponding to the date the torrent was published (i.e.: 1696870394). 

Added support for this field:
- Kinozal
- Rutor
- Rutracker