### PR TITLE
fix: использовать FileHandler для каждого движка, чтобы логи не перемешивались

### DIFF
--- a/engines/kinozal.py
+++ b/engines/kinozal.py
@@ -1,4 +1,4 @@
-# VERSION: 2.21
+# VERSION: 2.22
 # AUTHORS: imDMG [imdmgg@gmail.com]
 
 # Kinozal.tv search engine plugin for qBittorrent
@@ -78,15 +78,15 @@ ICON = (
 )
 
 # setup logging
-logging.basicConfig(
-    filemode="w",
-    filename=FILE_L,
-    format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
-    datefmt="%m-%d %H:%M",
-    level=logging.DEBUG,
-)
-
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+_fh = logging.FileHandler(FILE_L, mode="w")
+_fh.setFormatter(logging.Formatter(
+    fmt="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+    datefmt="%m-%d %H:%M",
+))
+logger.addHandler(_fh)
+logger.propagate = False
 
 
 def rng(t: int) -> range:

--- a/engines/nnmclub.py
+++ b/engines/nnmclub.py
@@ -1,4 +1,4 @@
-# VERSION: 2.23
+# VERSION: 2.24
 # AUTHORS: imDMG [imdmgg@gmail.com]
 
 # NoNaMe-Club search engine plugin for qBittorrent
@@ -81,15 +81,15 @@ ICON = (
 )
 
 # setup logging
-logging.basicConfig(
-    filemode="w",
-    filename=FILE_L,
-    format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
-    datefmt="%m-%d %H:%M",
-    level=logging.DEBUG,
-)
-
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+_fh = logging.FileHandler(FILE_L, mode="w")
+_fh.setFormatter(logging.Formatter(
+    fmt="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+    datefmt="%m-%d %H:%M",
+))
+logger.addHandler(_fh)
+logger.propagate = False
 
 
 def rng(t: int) -> range:

--- a/engines/rutor.py
+++ b/engines/rutor.py
@@ -1,4 +1,4 @@
-# VERSION: 1.18
+# VERSION: 1.19
 # AUTHORS: imDMG [imdmgg@gmail.com]
 
 # Rutor.org search engine plugin for qBittorrent
@@ -72,15 +72,15 @@ ICON = (
 )
 
 # setup logging
-logging.basicConfig(
-    filemode="w",
-    filename=FILE_L,
-    format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
-    datefmt="%m-%d %H:%M",
-    level=logging.DEBUG,
-)
-
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+_fh = logging.FileHandler(FILE_L, mode="w")
+_fh.setFormatter(logging.Formatter(
+    fmt="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+    datefmt="%m-%d %H:%M",
+))
+logger.addHandler(_fh)
+logger.propagate = False
 
 
 def rng(t: int) -> range:

--- a/engines/rutracker.py
+++ b/engines/rutracker.py
@@ -1,4 +1,4 @@
-# VERSION: 1.18
+# VERSION: 1.19
 # AUTHORS: imDMG [imdmgg@gmail.com]
 
 # rutracker.org search engine plugin for qBittorrent
@@ -77,15 +77,15 @@ ICON = (
 )
 
 # setup logging
-logging.basicConfig(
-    filemode="w",
-    filename=FILE_L,
-    format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
-    datefmt="%m-%d %H:%M",
-    level=logging.DEBUG,
-)
-
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+_fh = logging.FileHandler(FILE_L, mode="w")
+_fh.setFormatter(logging.Formatter(
+    fmt="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+    datefmt="%m-%d %H:%M",
+))
+logger.addHandler(_fh)
+logger.propagate = False
 
 
 def rng(t: int) -> range:


### PR DESCRIPTION
Closes #46

## Проблема

Когда qBittorrent запускает несколько поисковых движков в одном процессе, каждый из них вызывает `logging.basicConfig()`, который настраивает **корневой логгер**. Только первый вызов имеет эффект — последующие игнорируются. В результате все движки делят один файловый обработчик (от первого инициализированного движка), и логи из разных движков перемешиваются в одном файле.

## Решение

Замена `logging.basicConfig()` на `FileHandler`, привязанный напрямую к именованному логгеру каждого движка, с `propagate = False` — чтобы сообщения не уходили вверх к корневому логгеру.

Изменены файлы: `kinozal.py`, `nnmclub.py`, `rutor.py`, `rutracker.py`
