### PR TITLE
fix: перехват TimeoutError при редиректе для всех плагинов, увеличение таймаута до 15с

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 [![Python 3.10+](https://img.shields.io/badge/python-%3E%3D%20v3.10-blue)](https://www.python.org/downloads/release/python-3100/)
 # qBittorrent plugins
 
-## Rutracker.org ![v1.19](https://img.shields.io/badge/v1.19-blue)
+## Rutracker.org ![v1.20](https://img.shields.io/badge/v1.20-blue)
 Biggest russian torrent tracker.
 
-## Rutor.org ![v1.19](https://img.shields.io/badge/v1.19-blue)
+## Rutor.org ![v1.20](https://img.shields.io/badge/v1.20-blue)
 Popular free russian torrent tracker. http://rutor.info/ and http://rutor.is/ - actual domains at this time.
 
-## Kinozal.tv ![v2.22](https://img.shields.io/badge/v2.22-blue)
+## Kinozal.tv ![v2.23](https://img.shields.io/badge/v2.23-blue)
 Russian torrent tracker mostly directed on movies, but have other categories.
 
 The site has a restriction on downloading torrent files (10 by default or so), so I added the ability to open the magnet link instead the file.
 You can turn off the magnet link: in `kinozal.json` switch `"magnet": true` to `"magnet": false`
 
-## NNM-Club.me ![v2.24](https://img.shields.io/badge/v2.24-blue)
+## NNM-Club.me ![v2.25](https://img.shields.io/badge/v2.25-blue)
 One of biggest russian torrent tracker.
 
 _Note: the tracker is very sensitive to your proxy, if something doesn’t suit it, it turns on ddos protection and return 403 error. Use `proxychecker.py` to check your proxy_

--- a/engines/kinozal.py
+++ b/engines/kinozal.py
@@ -1,4 +1,4 @@
-# VERSION: 2.22
+# VERSION: 2.23
 # AUTHORS: imDMG [imdmgg@gmail.com]
 
 # Kinozal.tv search engine plugin for qBittorrent
@@ -354,23 +354,36 @@ class Kinozal:
         repeated: bool = False,
     ) -> bytes:
         try:
-            with self.session.open(url, data, 5) as r:
-                # checking that tracker isn't blocked
+            with self.session.open(url, data, 15) as r:
+                # check if the response is from the correct domain
                 if r.geturl().startswith((self.url, self.url_dl)):
                     return r.read()
                 raise EngineError(f"{url} is blocked. Try another proxy.")
-        except (URLError, HTTPError) as err:
-            error = str(err.reason)
-            reason = f"{url} is not response! Maybe it is blocked."
-            if "timed out" in error and not repeated:
-                logger.debug("Request timed out. Repeating...")
-                return self._request(url, data, True)
-            if "no host given" in error:
-                reason = "Proxy is bad, try another!"
-            elif isinstance(err, HTTPError):
-                reason = f"Request to {url} failed with status: {err.code}"
 
-            raise EngineError(reason) from err
+        except (URLError, HTTPError, TimeoutError) as err:
+            reason = getattr(err, "reason", None)
+            if isinstance(err, HTTPError):
+                raise EngineError(
+                    f"Request to {url} failed with status: {err.code}"
+                ) from err
+
+            if isinstance(err, TimeoutError) or isinstance(
+                reason, TimeoutError
+            ):
+                if not repeated:
+                    logger.debug("Request timed out. Repeating...")
+                    return self._request(url, data, True)
+
+                raise EngineError(
+                    f"{url} is not responding (timed out)."
+                ) from err
+
+            if isinstance(reason, str) and reason == "no host given":
+                raise EngineError("Proxy is bad, try another!") from err
+
+            raise EngineError(
+                f"{url} is not response! Maybe it is blocked."
+            ) from err
 
     def pretty_error(self, what: str, error: str) -> None:
         prettyPrinter(

--- a/engines/nnmclub.py
+++ b/engines/nnmclub.py
@@ -1,4 +1,4 @@
-# VERSION: 2.24
+# VERSION: 2.25
 # AUTHORS: imDMG [imdmgg@gmail.com]
 
 # NoNaMe-Club search engine plugin for qBittorrent
@@ -342,26 +342,36 @@ class NNMClub:
         repeated: bool = False,
     ) -> bytes:
         try:
-            with self.session.open(url, data, 5) as r:
-                # checking that tracker isn't blocked
+            with self.session.open(url, data, 15) as r:
+                # check if the response is from the correct domain
                 if r.geturl().startswith((self.url, self.url_dl)):
                     return r.read()
                 raise EngineError(f"{url} is blocked. Try another proxy.")
-        except (URLError, HTTPError) as err:
-            logger.debug(err)
-            error = str(err.reason)
-            reason = f"{url} is not response! Maybe it is blocked."
-            if "timed out" in error:
+
+        except (URLError, HTTPError, TimeoutError) as err:
+            reason = getattr(err, "reason", None)
+            if isinstance(err, HTTPError):
+                raise EngineError(
+                    f"Request to {url} failed with status: {err.code}"
+                ) from err
+
+            if isinstance(err, TimeoutError) or isinstance(
+                reason, TimeoutError
+            ):
                 if not repeated:
                     logger.debug("Request timed out. Repeating...")
                     return self._request(url, data, True)
-                reason = "Request timed out"
-            if "no host given" in error:
-                reason = "Proxy is bad, try another!"
-            elif isinstance(err, HTTPError):
-                reason = f"Request to {url} failed with status: {err.code}"
 
-            raise EngineError(reason) from err
+                raise EngineError(
+                    f"{url} is not responding (timed out)."
+                ) from err
+
+            if isinstance(reason, str) and reason == "no host given":
+                raise EngineError("Proxy is bad, try another!") from err
+
+            raise EngineError(
+                f"{url} is not response! Maybe it is blocked."
+            ) from err
 
     def pretty_error(self, what: str, error: str) -> None:
         prettyPrinter(

--- a/engines/rutor.py
+++ b/engines/rutor.py
@@ -1,4 +1,4 @@
-# VERSION: 1.19
+# VERSION: 1.20
 # AUTHORS: imDMG [imdmgg@gmail.com]
 
 # Rutor.org search engine plugin for qBittorrent
@@ -308,23 +308,36 @@ class Rutor:
         repeated: bool = False,
     ) -> bytes:
         try:
-            with self.session.open(url, data, 5) as r:
-                # checking that tracker isn't blocked
+            with self.session.open(url, data, 15) as r:
+                # check if the response is from the correct domain
                 if r.geturl().startswith((self.url, self.url_dl)):
                     return r.read()
                 raise EngineError(f"{url} is blocked. Try another proxy.")
-        except (URLError, HTTPError) as err:
-            error = str(err.reason)
-            reason = f"{url} is not response! Maybe it is blocked."
-            if "timed out" in error and not repeated:
-                logger.debug("Request timed out. Repeating...")
-                return self._request(url, data, True)
-            if "no host given" in error:
-                reason = "Proxy is bad, try another!"
-            elif isinstance(err, HTTPError):
-                reason = f"Request to {url} failed with status: {err.code}"
 
-            raise EngineError(reason) from err
+        except (URLError, HTTPError, TimeoutError) as err:
+            reason = getattr(err, "reason", None)
+            if isinstance(err, HTTPError):
+                raise EngineError(
+                    f"Request to {url} failed with status: {err.code}"
+                ) from err
+
+            if isinstance(err, TimeoutError) or isinstance(
+                reason, TimeoutError
+            ):
+                if not repeated:
+                    logger.debug("Request timed out. Repeating...")
+                    return self._request(url, data, True)
+
+                raise EngineError(
+                    f"{url} is not responding (timed out)."
+                ) from err
+
+            if isinstance(reason, str) and reason == "no host given":
+                raise EngineError("Proxy is bad, try another!") from err
+
+            raise EngineError(
+                f"{url} is not response! Maybe it is blocked."
+            ) from err
 
     def pretty_error(self, what: str, error: str) -> None:
         prettyPrinter(

--- a/engines/rutracker.py
+++ b/engines/rutracker.py
@@ -1,4 +1,4 @@
-# VERSION: 1.19
+# VERSION: 1.20
 # AUTHORS: imDMG [imdmgg@gmail.com]
 
 # rutracker.org search engine plugin for qBittorrent
@@ -321,23 +321,36 @@ class Rutracker:
         repeated: bool = False,
     ) -> bytes:
         try:
-            with self.session.open(url, data, 5) as r:
-                # checking that tracker isn't blocked
+            with self.session.open(url, data, 15) as r:
+                # check if the response is from the correct domain
                 if r.geturl().startswith((self.url, self.url_dl)):
                     return r.read()
                 raise EngineError(f"{url} is blocked. Try another proxy.")
-        except (URLError, HTTPError) as err:
-            error = str(err.reason)
-            reason = f"{url} is not response! Maybe it is blocked."
-            if "timed out" in error and not repeated:
-                logger.debug("Request timed out. Repeating...")
-                return self._request(url, data, True)
-            if "no host given" in error:
-                reason = "Proxy is bad, try another!"
-            elif isinstance(err, HTTPError):
-                reason = f"Request to {url} failed with status: {err.code}"
 
-            raise EngineError(reason) from err
+        except (URLError, HTTPError, TimeoutError) as err:
+            reason = getattr(err, "reason", None)
+            if isinstance(err, HTTPError):
+                raise EngineError(
+                    f"Request to {url} failed with status: {err.code}"
+                ) from err
+
+            if isinstance(err, TimeoutError) or isinstance(
+                reason, TimeoutError
+            ):
+                if not repeated:
+                    logger.debug("Request timed out. Repeating...")
+                    return self._request(url, data, True)
+
+                raise EngineError(
+                    f"{url} is not responding (timed out)."
+                ) from err
+
+            if isinstance(reason, str) and reason == "no host given":
+                raise EngineError("Proxy is bad, try another!") from err
+
+            raise EngineError(
+                f"{url} is not response! Maybe it is blocked."
+            ) from err
 
     def pretty_error(self, what: str, error: str) -> None:
         prettyPrinter(


### PR DESCRIPTION
## Проблема

При выполнении запроса сервер возвращает редирект 302. В ряде версий Python `TimeoutError`, возникающий при следовании редиректу, **не оборачивается** в `urllib.error.URLError`. Из-за этого блок `except (URLError, HTTPError)` в методе `_request()` его не перехватывал — логин завершался с необработанным исключением, и cookie никогда не сохранялись.

## Изменения

Исправление применено ко всем четырём плагинам (rutracker, kinozal, nnmclub, rutor):

- `TimeoutError` добавлен в список перехватываемых исключений `except (URLError, HTTPError, TimeoutError)`.
- Проверка на таймаут переписана: используется `isinstance(err, TimeoutError) or isinstance(reason, TimeoutError)` вместо разбора строки `err.reason`.
- Таймаут запроса увеличен с **5 с** до **15 с** для снижения ложных таймаутов на редиректе.
- Версии плагинов обновлены: rutracker 1.20, rutor 1.20, kinozal 2.23, nnmclub 2.25.
